### PR TITLE
Add withdrawn group to base LDAP tests database

### DIFF
--- a/tests/ldap_start
+++ b/tests/ldap_start
@@ -164,3 +164,10 @@ cn: mentors
 memberUid: blueshirt
 description: mentors group
 gidNumber: 3007
+
+dn: cn=withdrawn,ou=groups,o=sr
+objectClass: posixGroup
+cn: withdrawn
+memberUid: withdrawn
+description: withdrawn group
+gidNumber: 3008


### PR DESCRIPTION
So that running reset_ldap.py resets the users in the withdrawn group.
